### PR TITLE
feat: add integration test workflow file to publish charm

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -12,3 +12,4 @@ jobs:
     secrets: inherit
     with:
       channel: latest/edge
+      integration-test-workflow-file: integration_test.yaml


### PR DESCRIPTION
Applicable spec: None

### Overview

Add integration test workflow file path to the workflow.

### Rationale

Currently publish to edge workflow fails because it couldn't find the build output charm aproxy artifact from runs id (example: https://github.com/canonical/aproxy-operator/actions/runs/18351540952/job/52272574424 complaint even though the artifact exists in https://github.com/canonical/aproxy-operator/actions/runs/18351535486), which I suspected is due to missing integration test workflow file path.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [ ] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm/charm-development-best-practices/) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
Not needed for this PR.