### PR TITLE
fix: allow read from unit databags only

### DIFF
--- a/src/aproxy.py
+++ b/src/aproxy.py
@@ -333,18 +333,17 @@ class AproxyManager:
         if logger.isEnabledFor(logging.DEBUG):
             # Only read from unit databags to avoid RelationDataAccessError on
             # non-leader units (reading own application databag is forbidden).
-            units_ip: list[str] = []
-            for entity in relation.data.keys():
-                if isinstance(entity, ops.model.Unit):
-                    ip = relation.data[entity].get("private-address", "")
-                    if ip:
-                        units_ip.append(ip)
+            peer_unit_ips: list[str] = []
+            for unit in relation.units:
+                ip = relation.data[unit].get("private-address", "")
+                if ip:
+                    peer_unit_ips.append(ip)
 
             logger.debug(
-                "Resolved unit IP %s via relation '%s' (unit IPs: %s)",
+                "Resolved unit IP %s via relation '%s' (peer unit IPs: %s)",
                 current_unit_ip,
                 RELATION_NAME,
-                units_ip,
+                peer_unit_ips,
             )
 
         return current_unit_ip


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Change the unit ip retrieval to only read from unit databags instead of reading from all relation databags.

### Rationale

Reading from all relation data will cause error when non-leader unit is trying to read their own application databag.

Proof of fix tested locally (deploying multiple units of aproxy no longer cause error):
<img width="1204" height="478" alt="image" src="https://github.com/user-attachments/assets/8122d9d5-5d98-4f1c-8868-faeb61fb4722" />

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [x] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm/charm-development-best-practices/) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
Not needed.