### PR TITLE
chore: set permission package write

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -7,6 +7,8 @@ jobs:
   integration-tests:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
+    permissions:
+      packages: write
     with:
       load-test-enabled: false
       load-test-run-args: "-e LOAD_TEST_HOST=localhost"
@@ -14,8 +16,8 @@ jobs:
       trivy-image-config: "trivy.yaml"
       self-hosted-runner: true
       self-hosted-runner-label: "edge"
-      juju-channel: '3/stable'
-      provider: 'lxd'  
+      juju-channel: "3/stable"
+      provider: "lxd"
   allure-report:
     if: always() && !cancelled()
     needs:


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Set package permission to write for the github token from GitHub Actions.

### Rationale

Currently the publish charm is failing due to complaint that provided credentials are no longer valid for Charmhub.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm/charm-development-best-practices/) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
