### PR TITLE
fix: add annotations to fix typing problem in python 3.8

### DIFF
--- a/src/aproxy.py
+++ b/src/aproxy.py
@@ -1,9 +1,6 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-# pylint: disable=no-self-argument
-from __future__ import annotations
-
 """Aproxy controller.
 
 Contains:
@@ -11,6 +8,9 @@ Contains:
  - AproxyManager: install/remove/configure aproxy snap, build & apply nft configuration,
    create a systemd unit that re-applies nft configuration on boot for persistence.
 """
+
+# pylint: disable=no-self-argument
+from __future__ import annotations
 
 import ipaddress
 import logging
@@ -84,7 +84,7 @@ class AproxyConfig(BaseModel):
     intercept_ports_list: List[str]
 
     @classmethod
-    def from_charm(cls, charm: ops.CharmBase) -> "AproxyConfig":
+    def from_charm(cls, charm: ops.CharmBase) -> AproxyConfig:
         """Load and validate configuration from charm config.
 
         Args:


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm/charm-development-best-practices/) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
