### PR TITLE
docs: add landing pages

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -26,4 +26,5 @@ header:
   - 'zap_rules.tsv'
   - '**/*.md.j2'
   - 'uv.lock'
+  - 'docs/**'
   comment: on-failure

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,10 @@ Each revision is versioned by the date of the revision.
 
 Place any unreleased changes here, that are subject to release in coming versions :).
 
+## 2026-03-05
+
+- Add landing pages for how-to and reference section.
+
 ## 2026-02-19
 
 - Update tutorial and add workflow to test the tutorial using Spread.

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -1,3 +1,6 @@
+.. Copyright 2026 Canonical Ltd.
+.. See LICENSE file for licensing details.
+
 .. meta::
    :description: How-to guides for operating the aproxy charm, including basic operations, upgrades, and development. 
 

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -1,6 +1,3 @@
-.. Copyright 2026 Canonical Ltd.
-.. See LICENSE file for licensing details.
-
 .. meta::
    :description: How-to guides for operating the aproxy charm, including basic operations, upgrades, and development.
 

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -2,7 +2,7 @@
 .. See LICENSE file for licensing details.
 
 .. meta::
-   :description: How-to guides for operating the aproxy charm, including basic operations, upgrades, and development. 
+   :description: How-to guides for operating the aproxy charm, including basic operations, upgrades, and development.
 
 .. _how_to_index:
 
@@ -27,6 +27,7 @@ basic operations you can complete with the charm.
     :maxdepth: 1
 
     Configure <configure>
+    Integrate with COS <integrate-with-cos>
 
 Update and refresh
 ------------------

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -1,0 +1,50 @@
+.. meta::
+   :description: How-to guides for operating the aproxy charm, including basic operations, upgrades, and development. 
+
+.. _how_to_index:
+
+How-to guides
+=============
+
+The following guides cover key processes and common tasks for managing and
+using the aproxy charm.
+
+.. vale Canonical.013-Spell-out-numbers-below-10 = NO
+.. vale Canonical.500-Repeated-words = NO
+
+Basic operations
+----------------
+
+Once you've finished setting up the charm, now you can perform a number
+of actions with your deployment. These guides provide instructions on
+basic operations you can complete with the charm.
+
+.. toctree::
+    :hidden:
+    :maxdepth: 1
+
+    Configure <configure>
+
+Update and refresh
+------------------
+
+The following guides provide instructions on upgrading your deployment,
+including backup and restore processes.
+
+.. toctree::
+    :hidden:
+    :maxdepth: 1
+
+    Back up and restore <back-up-restore>
+    Upgrade <upgrade>
+
+Development
+-----------
+
+These guides can help you with contributing to the project.
+
+.. toctree::
+    :hidden:
+    :maxdepth: 1
+
+    Contribute <contribute>

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -28,6 +28,7 @@ including actions, configurations, and integrations.
     Actions <actions>
     Configurations <configurations>
     Integrations <integrations>
+    Metrics <metrics>
 
 .. vale Canonical.004-Canonical-product-names = YES
 

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,0 +1,41 @@
+.. meta::
+   :description: Technical reference documentation for the aproxy charm, including actions, configurations, and architecture.
+
+.. _reference_index:
+
+Reference
+=========
+
+This section contains technical details and information about the aproxy charm.
+
+Charm usage
+-----------
+
+The following pages provide more information about the charm's features,
+including actions, configurations, and integrations.
+
+.. vale Canonical.013-Spell-out-numbers-below-10 = NO
+.. vale Canonical.500-Repeated-words = NO
+.. vale Canonical.004-Canonical-product-names = NO
+
+.. toctree::
+    :hidden:
+    :maxdepth: 1
+
+    Actions <actions>
+    Configurations <configurations>
+    Integrations <integrations>
+
+.. vale Canonical.004-Canonical-product-names = YES
+
+Architecture and deployments
+----------------------------
+
+The following pages provide more details about the charm architecture and
+a high-level deployment with any required dependencies.
+
+.. toctree::
+    :hidden:
+    :maxdepth: 1
+
+    Charm architecture <charm-architecture>

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,3 +1,6 @@
+.. Copyright 2026 Canonical Ltd.
+.. See LICENSE file for licensing details.
+
 .. meta::
    :description: Technical reference documentation for the aproxy charm, including actions, configurations, and architecture.
 

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,6 +1,3 @@
-.. Copyright 2026 Canonical Ltd.
-.. See LICENSE file for licensing details.
-
 .. meta::
    :description: Technical reference documentation for the aproxy charm, including actions, configurations, and architecture.
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Add landing pages for how-to and reference section.

### Rationale

To aid user in navigating the documentations.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm/charm-development-best-practices/) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
