### PR TITLE
fix(jubilant): disable logging

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -103,10 +103,10 @@ def deploy_charms_fixture(
         pytestconfig: Pytest configuration object.
     """
     base = pytestconfig.getoption("--base", default="24.04")
-    juju.deploy("ubuntu", base=f"ubuntu@{base}", constraints={"virt-type": "virtual-machine"})
-    juju.deploy(aproxy_charm_file)
-    juju.integrate("ubuntu", "aproxy")
-    juju.cli("config", "aproxy", f"proxy-address={tinyproxy_url}:8888")
+    juju.deploy("ubuntu", base=f"ubuntu@{base}", constraints={"virt-type": "virtual-machine"}, log=False)
+    juju.deploy(aproxy_charm_file, log=False)
+    juju.integrate("ubuntu", "aproxy", log=False)
+    juju.config("aproxy", {"proxy-address": f"{tinyproxy_url}:8888"}, log=False)
     juju.wait(jubilant.all_active, timeout=20 * 60)
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -46,8 +46,8 @@ def test_aproxy_reads_model_proxy(juju, aproxy_app, tinyproxy_url):
     act: set the model config juju-http-proxy, then unset aproxy proxy-address.
     assert: aproxy reads proxy values from the model config.
     """
-    juju.cli("model-config", f"juju-http-proxy=http://{tinyproxy_url}:8888")
-    juju.cli("config", "aproxy", "--reset", "proxy-address")
+    juju.model_config({"juju-http-proxy": f"http://{tinyproxy_url}:8888"}, log=False)
+    juju.config("aproxy", reset="proxy-address", log=False)
 
     juju.wait(jubilant.all_active, timeout=5 * 60)
     units = juju.status().get_units(aproxy_app.name)

--- a/tests/integration/tinyproxy.py
+++ b/tests/integration/tinyproxy.py
@@ -71,6 +71,7 @@ def deploy_tinyproxy(juju: jubilant.Juju, base: str) -> str:
         base=base,
         config={"src-overwrite": json.dumps({"any_charm.py": any_charm_py})},
         constraints={"virt-type": "virtual-machine"},
+        log=False,
     )
 
     # Wait until the service is up


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Disable logging for jubilant commands `deploy`, `config`, and `model_config`.

### Rationale

To avoid commands and its secrets being logged.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm/charm-development-best-practices/) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
