### PR TITLE
Disable jubilant logging for juju.deploy, juju.config and juju.exec

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -103,8 +103,10 @@ def deploy_charms_fixture(
         pytestconfig: Pytest configuration object.
     """
     base = pytestconfig.getoption("--base", default="24.04")
-    juju.deploy("ubuntu", base=f"ubuntu@{base}", constraints={"virt-type": "virtual-machine"})
-    juju.deploy(aproxy_charm_file)
+    juju.deploy(
+        "ubuntu", base=f"ubuntu@{base}", constraints={"virt-type": "virtual-machine"}, log=False
+    )
+    juju.deploy(aproxy_charm_file, log=False)
     juju.integrate("ubuntu", "aproxy")
     juju.cli("config", "aproxy", f"proxy-address={tinyproxy_url}:8888")
     juju.wait(jubilant.all_active, timeout=20 * 60)

--- a/tests/integration/tinyproxy.py
+++ b/tests/integration/tinyproxy.py
@@ -71,6 +71,7 @@ def deploy_tinyproxy(juju: jubilant.Juju, base: str) -> str:
         base=base,
         config={"src-overwrite": json.dumps({"any_charm.py": any_charm_py})},
         constraints={"virt-type": "virtual-machine"},
+        log=False,
     )
 
     # Wait until the service is up


### PR DESCRIPTION
Add log=False to all juju.deploy(), juju.config() and juju.exec() calls in integration tests.