### PR TITLE
chore: migrate from self-hosted edge runner to GitHub-hosted runner

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -21,8 +21,6 @@ jobs:
     with:
       trivy-fs-enabled: true
       trivy-image-config: "trivy.yaml"
-      self-hosted-runner: true
-      self-hosted-runner-label: "edge"
       juju-channel: "3/stable"
       provider: "lxd"
       extra-arguments: "--base ${{ matrix.base }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,6 @@ jobs:
     permissions:
       pull-requests: write
     with:
-      self-hosted-runner: true
-      self-hosted-runner-label: "edge"
+      self-hosted-runner: false
+      runs-on-base: ubuntu-24.04
       with-uv: true


### PR DESCRIPTION
## Summary

This PR migrates unit and integration test workflows from the self-hosted `amd64-noble-medium-edge-ps7` ("edge") runner to GitHub-hosted `ubuntu-24.04` runners, which are free and unlimited for public repositories.

The `self-hosted-runner` and `self-hosted-runner-label` inputs are removed from the reusable workflow calls; the operator-workflows default then falls back to GitHub-hosted runners.