### PR TITLE
chore: use default values for github runners in test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,4 @@ jobs:
     permissions:
       pull-requests: write
     with:
-      self-hosted-runner: true
-      self-hosted-runner-label: "edge"
       with-uv: true


### PR DESCRIPTION
Use Github Runners for simple tests